### PR TITLE
Fix tests with new filtering

### DIFF
--- a/StorageServiceUnitTests/Storage/Providers/StatementProviderTest.cs
+++ b/StorageServiceUnitTests/Storage/Providers/StatementProviderTest.cs
@@ -1,4 +1,5 @@
 
+using AutoMapper;
 using Microsoft.Extensions.Logging;
 using Storage.Controllers.MeetingInfo.DTOs;
 using Storage.Providers;
@@ -10,6 +11,7 @@ namespace StorageServiceUnitTests.Storage.Providers
     public class StatementProviderTests
     {
         private readonly Mock<IStatementsRepository> _statementsRepository;
+        private readonly Mock<IMapper> _mapper;
         private readonly Mock<IVideoSyncRepository> _videoSyncRepository;
         private readonly Mock<IMeetingsRepository> _meetingsRepository;
         private readonly Mock<ILogger<StatementProvider>> _logger;
@@ -24,6 +26,7 @@ namespace StorageServiceUnitTests.Storage.Providers
             _videoSyncRepository = new Mock<IVideoSyncRepository>();
             _meetingsRepository = new Mock<IMeetingsRepository>();
             _logger = new Mock<ILogger<StatementProvider>>();
+            _mapper = new Mock<IMapper>();
             _statementProvider = new StatementProvider(_logger.Object,
             _statementsRepository.Object,
             _videoSyncRepository.Object,
@@ -64,17 +67,40 @@ namespace StorageServiceUnitTests.Storage.Providers
         {
             var statements = new List<Statement>
             {
-                new Statement { MeetingID = "meetingA", EventID = new Guid(), Started = DateTime.UtcNow },
-                new Statement { MeetingID = "meetingB", EventID = new Guid() },
+                new Statement { MeetingID = "1234567890", EventID = new Guid(), Started = new DateTime(2023, 5, 15), Ended = new DateTime(2023, 5, 15), DurationSeconds = 54 },
+                new Statement { MeetingID = "meetingB", EventID = new Guid(), Started = new DateTime(2023, 5, 15), Ended = new DateTime(2023, 5, 15), DurationSeconds = 54 },
             };
             var videoSyncs = new List<VideoSync>
             {
-                new VideoSync { MeetingID = "meetingA", Timestamp = DateTime.UtcNow, VideoPosition = 0 },
+                new VideoSync { MeetingID = "1234567890", Timestamp = new DateTime(2023, 5, 14), VideoPosition = 34 },
                 new VideoSync { MeetingID = "meetingA", Timestamp = null, VideoPosition = 43 }
+            };
+            var meeting = new Meeting
+            {
+                MeetingID = "meetingA",
+                MeetingStarted = new DateTime(2023, 5, 15),
+                MeetingEnded = new DateTime(2023, 5, 15),
+                MeetingSequenceNumber = 1,
+            };
+            var statement = new Statement
+            {
+                MeetingID = "meetingA",
+                EventID = new Guid(),
+                Started = DateTime.UtcNow,
+                Ended = DateTime.UtcNow,
+                DurationSeconds = 45,
+            };
+            var webApiStatementsDTO = new WebApiStatementsDTO
+            {
+                MeetingId = "meetingA",
+                VideoPosition = 54,
+                VideoLink = "videoLink",
             };
 
             _statementsRepository.Setup(x => x.GetSatementsByName(personName, year, lang)).Returns(Task.FromResult(statements));
-            _videoSyncRepository.Setup(x => x.GetVideoPositions("meetingA")).Returns(Task.FromResult(videoSyncs));
+            _videoSyncRepository.Setup(x => x.GetVideoPositions("1234567890")).Returns(Task.FromResult(videoSyncs));
+            _meetingsRepository.Setup(x => x.FetchMeetingById("1234567890")).Returns(Task.FromResult(meeting));
+            _mapper.Setup(x => x.Map<WebApiStatementsDTO>(statement)).Returns(webApiStatementsDTO);
 
             var result = await _statementProvider.GetStatementsByPerson(personName, year, lang);
 
@@ -83,7 +109,7 @@ namespace StorageServiceUnitTests.Storage.Providers
         }
 
         [Fact]
-        public async void GetStatementsByPerson_ReturnPossibleNullData()
+        public async void GetStatementsByPerson_ReturnEmptyList()
         {
             var statements = new List<Statement>
             {
@@ -102,7 +128,7 @@ namespace StorageServiceUnitTests.Storage.Providers
             var result = await _statementProvider.GetStatementsByPerson(personName, year, lang);
 
             _statementsRepository.Verify(x => x.GetSatementsByName(personName, year, lang), Times.Once);
-            Assert.NotEmpty(result);
+            Assert.Empty(result);
         }
     }
 }


### PR DESCRIPTION
Add a hotfix for Provider test. The new filtering logic broke a test when the logic was moved to provider instead. This will make the tests passable.