### PR TITLE
New statements endpoint ("lookup")

### DIFF
--- a/Storage/Controllers/StatementController.cs
+++ b/Storage/Controllers/StatementController.cs
@@ -54,15 +54,29 @@ namespace Storage.Controllers
 
         [HttpGet("lookup")]
         public async Task<IActionResult> GetStatementsByPersonOrDate(
-            [FromQuery]List<string> names,
+            [FromQuery]string? names,
             [FromQuery]DateTime? startDate,
             [FromQuery]DateTime? endDate)
         {
             try
             {
-                if ((names == null || !names.Any()) && !startDate.HasValue && !endDate.HasValue)
+                var nameList = string.IsNullOrWhiteSpace(names) 
+                       ? new List<string>() 
+                       : names.Split(',')
+                              .Select(name => name.Trim())
+                              .Where(name => !string.IsNullOrEmpty(name))
+                              .ToList();
+
+                // Check if both dates are provided together or none at all
+                if ((startDate.HasValue && !endDate.HasValue) || (!startDate.HasValue && endDate.HasValue))
                 {
-                    return BadRequest(new { Message = "Vähintään yksi hakusuodatin on oltava asetettuna (nimilista (names) tai päivämäärien väli (startDate ja endDate))"});
+                    return BadRequest(new { Message = "Sekä startDate että endDate on asetettava, jos päivämääräsuodatus on käytössä" });
+                }
+
+                // Ensure at least one filter is provided (either names or complete date range)
+                if (!nameList.Any() && !startDate.HasValue && !endDate.HasValue)
+                {
+                    return BadRequest(new { Message = "Vähintään yksi hakusuodatin on oltava asetettuna (nimilista (names) tai päivämäärien väli (startDate ja endDate))" });
                 }
 
                 if (endDate.HasValue)
@@ -70,8 +84,9 @@ namespace Storage.Controllers
                     endDate = endDate.Value.Date.AddDays(1).AddTicks(-1);
                 }
 
-                _logger.LogInformation($"GetStatementsByPersonOrDate {string.Join(", ", names)}, {startDate} {endDate}");
-                var statements = await _statementProvider.GetStatementsByPersonOrDate(names, startDate, endDate);
+                _logger.LogInformation($"GetStatementsByPersonOrDate {string.Join(", ", nameList)}, {startDate} {endDate}");
+
+                var statements = await _statementProvider.GetStatementsByPersonOrDate(nameList, startDate, endDate);
                 return new OkObjectResult(statements);
             }
             catch (Exception ex)

--- a/Storage/Controllers/StatementController.cs
+++ b/Storage/Controllers/StatementController.cs
@@ -51,5 +51,34 @@ namespace Storage.Controllers
                 return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
+
+        [HttpGet("lookup")]
+        public async Task<IActionResult> GetStatementsByPersonOrDate(
+            [FromQuery]List<string> names,
+            [FromQuery]DateTime? startDate,
+            [FromQuery]DateTime? endDate)
+        {
+            try
+            {
+                if ((names == null || !names.Any()) && !startDate.HasValue && !endDate.HasValue)
+                {
+                    return BadRequest(new { Message = "Vähintään yksi hakusuodatin on oltava asetettuna (nimilista (names) tai päivämäärien väli (startDate ja endDate))"});
+                }
+
+                if (endDate.HasValue)
+                {
+                    endDate = endDate.Value.Date.AddDays(1).AddTicks(-1);
+                }
+
+                _logger.LogInformation($"GetStatementsByPersonOrDate {string.Join(", ", names)}, {startDate} {endDate}");
+                var statements = await _statementProvider.GetStatementsByPersonOrDate(names, startDate, endDate);
+                return new OkObjectResult(statements);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "GetStatementsByPersonOrDate failed");
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
     }
 }

--- a/Storage/Repositories/StatementsRepository.cs
+++ b/Storage/Repositories/StatementsRepository.cs
@@ -41,49 +41,60 @@ namespace Storage.Repositories
             _databaseConnectionFactory = databaseConnectionFactory;
         }
 
-    public async Task<List<Statement>> GetStatementsByPersonOrDate(List<string> names, DateTime? startDate, DateTime? endDate)
-    {
-        string? namesString = names != null && names.Any()
-            ? string.Join(",", names.Select(name => name.Trim()))
-            : null;
-
-        var sqlQuery = @"
-            select
-                statements.meeting_id,
-                person,
-                started,
-                ended,
-                speech_type,
-                duration_seconds,
-                additional_info_fi,
-                additional_info_sv,
-                agenda_items.title as title,
-                agenda_items.agenda_point as case_number
-            from
-                statements
-            join
-                meeting_events on statements.event_id = meeting_events.event_id
-            join
-                agenda_items on 
-                    meeting_events.meeting_id = agenda_items.meeting_id and
-                    agenda_items.agenda_point = meeting_events.case_number::int8
-            where
-                (@names IS NULL OR person = ANY(string_to_array(@names, ',')))
-        ";
-
-        // Append date filters conditionally if provided
-        if (startDate.HasValue)
+        public async Task<List<Statement>> GetStatementsByPersonOrDate(List<string> names, DateTime? startDate, DateTime? endDate)
         {
-            sqlQuery += " AND started >= @startDate";
-        }
-        if (endDate.HasValue)
-        {
-            sqlQuery += " AND ended <= @endDate";
+            var sqlQuery = @"
+                select
+                    statements.meeting_id,
+                    person,
+                    started,
+                    ended,
+                    speech_type,
+                    duration_seconds,
+                    additional_info_fi,
+                    additional_info_sv,
+                    agenda_items.title as title,
+                    agenda_items.agenda_point as case_number
+                from
+                    statements
+                join
+                    meeting_events on statements.event_id = meeting_events.event_id
+                join
+                    agenda_items on 
+                        meeting_events.meeting_id = agenda_items.meeting_id and
+                        agenda_items.agenda_point = meeting_events.case_number::int8
+                where 1=1
+            ";
+
+            if (names != null && names.Any())
+            {
+                var nameConditions = new List<string>();
+
+                foreach (var name in names)
+                {
+                    var words = name.Split(' ').Select(word => word.Trim());
+                    var wordConditions = words.Select(word => $"person ILIKE '%{word}%'");
+
+                    nameConditions.Add("(" + string.Join(" AND ", wordConditions) + ")");
+                }
+
+                sqlQuery += " AND (" + string.Join(" OR ", nameConditions) + ")";
+            }
+
+            if (startDate.HasValue)
+            {
+                sqlQuery += " AND started >= '" + startDate.Value.ToString("yyyy-MM-dd") + "'";
+            }
+            if (endDate.HasValue)
+            {
+                sqlQuery += " AND ended <= '" + endDate.Value.ToString("yyyy-MM-dd") + "'";
+            }
+
+            using var connection = await _databaseConnectionFactory.CreateOpenConnection();
+
+            return (await connection.QueryAsync<Statement>(sqlQuery)).ToList();
         }
 
-        using var connection = await _databaseConnectionFactory.CreateOpenConnection();
-        return (await connection.QueryAsync<Statement>(sqlQuery, new { names = namesString, startDate, endDate })).ToList();
-    }
 
         public async Task<List<Statement>> GetSatementsByName(string name, int year, string lang)
         {

--- a/Storage/Repositories/StatementsRepository.cs
+++ b/Storage/Repositories/StatementsRepository.cs
@@ -19,6 +19,8 @@ namespace Storage.Repositories
 
         Task<List<Statement>> GetSatementsByName(string name, int year, string lang);
 
+        Task<List<Statement>> GetStatementsByPersonOrDate(List<string> names, DateTime? startDate, DateTime? endDate);
+
         Task<List<StatementReservation>> GetStatementReservations(string meetingId, string agendaPoint);
 
         Task<List<ReplyReservation>> GetReplyReservations(string meetingId, string agendaPoint);
@@ -38,6 +40,50 @@ namespace Storage.Repositories
             _logger = logger;
             _databaseConnectionFactory = databaseConnectionFactory;
         }
+
+    public async Task<List<Statement>> GetStatementsByPersonOrDate(List<string> names, DateTime? startDate, DateTime? endDate)
+    {
+        string? namesString = names != null && names.Any()
+            ? string.Join(",", names.Select(name => name.Trim()))
+            : null;
+
+        var sqlQuery = @"
+            select
+                statements.meeting_id,
+                person,
+                started,
+                ended,
+                speech_type,
+                duration_seconds,
+                additional_info_fi,
+                additional_info_sv,
+                agenda_items.title as title,
+                agenda_items.agenda_point as case_number
+            from
+                statements
+            join
+                meeting_events on statements.event_id = meeting_events.event_id
+            join
+                agenda_items on 
+                    meeting_events.meeting_id = agenda_items.meeting_id and
+                    agenda_items.agenda_point = meeting_events.case_number::int8
+            where
+                (@names IS NULL OR person = ANY(string_to_array(@names, ',')))
+        ";
+
+        // Append date filters conditionally if provided
+        if (startDate.HasValue)
+        {
+            sqlQuery += " AND started >= @startDate";
+        }
+        if (endDate.HasValue)
+        {
+            sqlQuery += " AND ended <= @endDate";
+        }
+
+        using var connection = await _databaseConnectionFactory.CreateOpenConnection();
+        return (await connection.QueryAsync<Statement>(sqlQuery, new { names = namesString, startDate, endDate })).ToList();
+    }
 
         public async Task<List<Statement>> GetSatementsByName(string name, int year, string lang)
         {


### PR DESCRIPTION
This PR adds a new endpoint to storage-api to allow fetching statements from the database using names separated by commas, and a startDate and endDate. A fetch cannot be done without using at least one of these queries (either date range or names).